### PR TITLE
Fix Example Usage of Guard

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ fn main() {
 
     // Time the execution of a block by creating a guard.
     let z = {
-        let _ = flame::start_guard("cpu-heavy calculation");
+        let _guard = flame::start_guard("cpu-heavy calculation");
         cpu_heavy_operations_1();
         // Notes can be used to annotate a particular instant in time.
         flame::note("something interesting happened");


### PR DESCRIPTION
`let _` is semantically different from `let _guard`, as the former doesn't create a binding at all, which means the guard is never used, so it can't measure any times at all, while the latter creates a binding that gets dropped properly.