### PR TITLE
Remove pub qualifier from local function which causes error E0447

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,7 +160,7 @@ fn event_to_span<'a, I: Iterator<Item = &'a Event>>(event: &Event, events: &mut 
                         continue;
                     }
                 }
-                
+
                 // Otherwise, it's a new node
                 span.children.push(child);
             }
@@ -365,7 +365,7 @@ pub fn debug() {
 }
 
 pub fn dump_stdout() {
-    pub fn print_span(span: &Span) {
+    fn print_span(span: &Span) {
         let mut buf = String::new();
         for _ in 0 .. span.depth {
             buf.push_str("  ");


### PR DESCRIPTION
Running the example code generated the following error:

```rust
$ cargo run --example demo
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling libc v0.1.12
/Users/pastoraleman/.cargo/registry/src/github.com-88ac128001ac3a9a/libc-0.1.12/rust/src/liblibc/lib.rs:81:21: 81:39 warning: lint raw_pointer_derive has been removed: using derive with raw pointers is ok
/Users/pastoraleman/.cargo/registry/src/github.com-88ac128001ac3a9a/libc-0.1.12/rust/src/liblibc/lib.rs:81 #![allow(bad_style, raw_pointer_derive)]
                                                                                                                        ^~~~~~~~~~~~~~~~~~
   Compiling clock_ticks v0.1.0
   Compiling flame v0.1.4 (file:///Users/pastoraleman/dev_sandbox/flame)
src/lib.rs:368:5: 379:6 error: visibility has no effect inside functions or block expressions [E0447]
src/lib.rs:368     pub fn print_span(span: &Span) {
src/lib.rs:369         let mut buf = String::new();
src/lib.rs:370         for _ in 0 .. span.depth {
src/lib.rs:371             buf.push_str("  ");
src/lib.rs:372         }
src/lib.rs:373         buf.push_str("| ");
               ...
src/lib.rs:368:5: 379:6 help: run `rustc --explain E0447` to see a detailed explanation
error: aborting due to previous error
Could not compile `flame`.

To learn more, run the command again with --verbose.
```

Removing the "pub" qualifier from the local function allows the example to run correctly.