### PR TITLE
add an `end_with(_, _)` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,6 +277,16 @@ pub fn end<S: Into<StrCow>>(name: S) -> u64 {
     end_impl(name, false)
 }
 
+/// Ends the current Span and returns a given result.
+///
+/// This is mainly useful for code generation / plugins where
+/// wrapping all returned expressions is easier than creating
+/// a temporary variable to hold the result.
+pub fn end_with<S: Into<StrCow>, R>(name: S, result: R) -> R {
+    end_impl(name, false)
+    result
+}
+
 /// Ends the current Span and returns the number of
 /// nanoseconds that passed.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,7 +283,7 @@ pub fn end<S: Into<StrCow>>(name: S) -> u64 {
 /// wrapping all returned expressions is easier than creating
 /// a temporary variable to hold the result.
 pub fn end_with<S: Into<StrCow>, R>(name: S, result: R) -> R {
-    end_impl(name, false)
+    end_impl(name, false);
     result
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -100,3 +100,13 @@ fn cant_note() {
     flame::clear();
     flame::note("hi", None);
 }
+
+#[test]
+fn end_with() {
+    fn _inner() -> u32 {
+        flame::clear();
+        flame::start("w");
+        flame::end_with("w", 1)
+    }
+    assert_eq!(1, _inner());
+}


### PR DESCRIPTION
Rationale: We got some problems reported on flamer that the drop impls of
span guards are sometimes optimized out. Also we probably don't need to
care about panics (or *want* to record an unclosed span in that case
which would not happen with `start_guard(_)`).

This fixes #8.