### PR TITLE
new feature: frame(name, || ..)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,15 @@ pub fn start_guard<S: Into<StrCow>>(name: S) -> SpanGuard {
     SpanGuard { name: Some(name), collapse: false }
 }
 
+/// Run a callable within a Frame.
+pub fn frame<S: Into<StrCow>, R, F: FnOnce() -> R>(name: S, f: F) -> R {
+    let name = name.into();
+    let _guard = start_guard(name);
+    let result = f();
+    _guard.end(); // to avoid optimizing out the guard
+    result
+}
+
 /// Starts and ends a `Span` that lasts for the duration of the
 /// function `f`.
 pub fn span_of<S, F, R>(name: S, f: F) -> R where

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -110,3 +110,11 @@ fn end_with() {
     }
     assert_eq!(1, _inner());
 }
+
+#[test]
+fn framed() {
+    fn _inner(i: u32) -> u32 {
+        i * 2
+    }
+    assert_eq!(42, flame::frame("f", || _inner(21)));
+}


### PR DESCRIPTION
This just adds a guard (and `end`s it so it doesn't get optimized out) to a closure.

I'm open to bikeshedding the name.