### PR TITLE
Add `cfg(feature = "json")` to `extern crate serde_derive`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,8 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate thread_id;
+
+#[cfg(feature = "json")]
 #[macro_use]
 extern crate serde_derive;
 #[cfg(feature = "json")]


### PR DESCRIPTION
I noticed that the crate would not compile with `default-features = false`. Not really much else to this