### PR TITLE
Expose dump_html_custom

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,4 +551,4 @@ pub fn dump_json<W: std::io::Write>(out: &mut W) -> std::io::Result<()> {
     out.write_all(serde_json::to_string_pretty(&threads()).unwrap().as_bytes())
 }
 
-pub use html::dump_html;
+pub use html::{dump_html, dump_html_custom};


### PR DESCRIPTION
It's handy to dump Spans from a certain thread using the existing html visualisation, especially when the primary one is only acting as a host/bootstrap (e.g. with `cargo run`).